### PR TITLE
bugfix: Fix parsing auth headers

### DIFF
--- a/src/code_examples_generator/resource_parser.clj
+++ b/src/code_examples_generator/resource_parser.clj
@@ -1,9 +1,28 @@
 (ns code-examples-generator.resource-parser
   "Methods for parsing HTTP requests from RAML map."
   (:require
-   [clojure.string :refer [starts-with?]]
-   [ring.util.codec :refer [form-encode]]))
+   [ring.util.codec :refer [form-encode]]
+   [clojure.string :as str]))
 
+
+(defmulti parse-property
+  "According to RAML spec:
+   > RAML parsers MUST parse the content of the file as RAML content and 
+   >append the parsed structures to the RAML document node if the included 
+   > file has a .raml, .yml, or .yaml extension. 
+   `raml-clj-parser` does not seem to parse includes properly so this method
+   checks whether input is a string and parses it to a map if needed"
+  class)
+
+(defmethod parse-property String
+  [s]
+  (let [match "example: "
+        example (->> (str/split s #"\n")
+                     (filter #(str/starts-with? % match))
+                     first)]
+    (str/replace-first example (re-pattern match) "")))
+
+(defmethod parse-property :default [m] (:example m))
 
 ;; TODO maybe report that certain values are nil? It will be easier to fix the docs.
 ;; TODO Reporting should be done on higher levels
@@ -12,7 +31,7 @@
   "Parse node and return a map of key-value pairs where key is key and 
    value is taken from `:example`. Not recursive!"
   [m]
-  (into {} (map (fn [[k {v :example}]] [k v]) m)))
+  (into {} (map (fn [[k v]] [k (parse-property v)]) m)))
 
 (defn get-resources
   "Returns a sequence of vectors where each one consists of two values:
@@ -20,7 +39,7 @@
    b) resource node
    e.g. '([s m] [s m])"
   [m]
-  (let [keys (->> m keys (filter #(and (string? %) (starts-with? % "/"))) set)]
+  (let [keys (->> m keys (filter #(and (string? %) (str/starts-with? % "/"))) set)]
     (filter (fn [[k _]] (contains? keys k)) m)))
 
 


### PR DESCRIPTION
raml-clj-parser does not parse included fragments correctly to
document nodes but leaves them as strings. Wrote a workaround to
cover such cases.