### PR TITLE
chore: added log4j and ignore ring-curl WARN

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,8 @@
   :main code-examples-generator.core
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.cli "0.4.2"]
+                 [org.clojure/tools.logging "0.4.1"]
+                 [org.slf4j/slf4j-log4j12 "1.6.2"]
                  [raml-clj-parser "0.1.1-SNAPSHOT"]
                  [ring/ring-codec "1.1.2"]
                  [ring-curl "1.0.1"]

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootLogger=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p %c: %m%n
+
+# make logger ignore ring-curl complaints about empty :body
+log4j.appender.console.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.console.filter.01.StringToMatch=Unable to write the body [ nil ]
+log4j.appender.console.filter.01.AcceptOnMatch=false


### PR DESCRIPTION
Ring curl warns about empty body which is annoying and does not
affect cURL generation. Added log4j and a filter to remove
log output about empty body