### PR TITLE
fix: trailing ? in params

### DIFF
--- a/test/code_examples_generator/resource_parser_test.clj
+++ b/test/code_examples_generator/resource_parser_test.clj
@@ -17,6 +17,9 @@
       {:X-Pot-1 {}}
       {:X-Pot-1 {} :X-Pot-2 {:X-Pot-3 nil}}
       {:X-Pot-1 {:example "{:X-Pot-2 {:example 1}}"}}))
+  (testing "? identifies an optional parameter and should be removed"
+    (is (= {:test "ok"}
+           (coerce-examples->values {:test? {:example "ok"}}))))
   (testing "value can be a stringified map"
     (is (= {:test "my-example"}
            (coerce-examples->values {:test "description: ok\ntype: object\nexample: my-example"}))))


### PR DESCRIPTION
According to RAML spec trailing question mark identifies
an optional parameter. Strip it from parameter keys in
code examples.