### PR TITLE
feature: code-examples as markdown

### DIFF
--- a/resources/templates/slate.md
+++ b/resources/templates/slate.md
@@ -1,0 +1,22 @@
+```python
+{% include "templates/python.py" %}
+```
+
+```shell
+{% include "templates/curl" %}
+```
+
+```javascript
+{% include "templates/unirest.node.js" %}
+```
+
+```java
+System.out.println("Java example missing. Why not contribute one for us?");
+```
+
+> The above example should return `JSON` structured like this:
+
+```json
+here should be example response!
+
+```

--- a/src/code_examples_generator/fs_utils.clj
+++ b/src/code_examples_generator/fs_utils.clj
@@ -24,7 +24,7 @@
   ([]
    (get-templates "templates"))
   ([path]
-   (list "curl", "python.py", "unirest.node.js")))
+   (list "curl", "python.py", "unirest.node.js" "slate.md")))
    ;; (prn path)
    ;; (prn (io/resource path))
    ;; (prn (->> path io/resource .getFile))


### PR DESCRIPTION
PlatformOfTrust/docs requires code examples in a specific format
(markdown with all examples combined). It will be injected into slate 
files. Added a combined markdown template that includes existing 
language specific templates and has a placeholder for response example.