### PR TITLE
fix: send payload as`json` param

### DIFF
--- a/resources/templates/python.py
+++ b/resources/templates/python.py
@@ -4,7 +4,7 @@ response = requests.{{request-method|name}}(
     '{{scheme}}://{{server-name}}{{uri}}',
     {% if query-string %}params='{{query-string|safe}}',{% endif %}
     {% if headers %}headers={{headers|json|safe}},{% endif %}
-    {% if body %}data=({{body|json|safe}}){% endif %}
+    {% if body %}json=({{body|json|safe}}){% endif %}
 )
 
 json_response = response.json()


### PR DESCRIPTION
Use `json` param instead of `data` for payload in Python template.